### PR TITLE
Remove unnecessary openvswitch-datapath-dkms package

### DIFF
--- a/OpenStack-Icehouse-Installation.rst
+++ b/OpenStack-Icehouse-Installation.rst
@@ -840,7 +840,7 @@ The network node runs the Networking plug-in and different agents (see the Figur
 
 * Install the Networking components::
 
-    apt-get install -y neutron-plugin-ml2 neutron-plugin-openvswitch-agent openvswitch-datapath-dkms dnsmasq neutron-l3-agent neutron-dhcp-agent
+    apt-get install -y neutron-plugin-ml2 neutron-plugin-openvswitch-agent dnsmasq neutron-l3-agent neutron-dhcp-agent
 
 * Update /etc/neutron/neutron.conf::
 
@@ -1108,7 +1108,7 @@ It uses KVM as hypervisor and runs nova-compute, the Networking plug-in and laye
 
 * Install the Networking components::
     
-    apt-get install -y neutron-common neutron-plugin-ml2 neutron-plugin-openvswitch-agent openvswitch-datapath-dkms
+    apt-get install -y neutron-common neutron-plugin-ml2 neutron-plugin-openvswitch-agent
 
 
 * Update /etc/neutron/neutron.conf::


### PR DESCRIPTION
Kernel openvswitch module is included in Ubuntu Trusty 14.04
# modinfo openvswitch

filename:       /lib/modules/3.13.0-32-generic/kernel/net/openvswitch/openvswitch.ko
license:        GPL
description:    Open vSwitch switching datapath
srcversion:     47D3079FB6731A4B46CED6E
depends:        libcrc32c,vxlan,gre
intree:         Y
vermagic:       3.13.0-32-generic SMP mod_unload modversions 
signer:         Magrathea: Glacier signing key
sig_key:        5E:3C:0F:9C:A6:E3:65:43:53:5F:A2:BB:5B:70:9E:84:F1:6D:A7:C7
sig_hashalgo:   sha512
